### PR TITLE
Add option to only use forced subtitle tracks if explicitly requested

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,10 @@ Check the audio track when playback starts and compare with the latest predictio
 
 Auto-Select Mode enables this intrinsically.
 
+### Only Use Forced Subtitles if Explicitly Included (default no)
+
+By default, when searching for subtitle tracks with a specific language, forced subtitles will be included in the search results and treated the same as other tracks. This means that there's no way to write a rule that specifically excludes forced subtitle tracks. By setting `explicit_forced_subs=yes`, forced subtitles will never be chosen unless a rule explicitly includes "forced" in `slang`.
+
 ## Examples
 
 The [sub_select.conf](/sub_select.conf) file contains all of the options for the script and their defaults. The [sub-select.json](/sub-select.json) file contains an example set of track matches.

--- a/README.md
+++ b/README.md
@@ -102,10 +102,6 @@ Check the audio track when playback starts and compare with the latest predictio
 
 Auto-Select Mode enables this intrinsically.
 
-### Only Use Forced Subtitles if Explicitly Included (default no)
-
-By default, when searching for subtitle tracks with a specific language, forced subtitles will be included in the search results and treated the same as other tracks. This means that there's no way to write a rule that specifically excludes forced subtitle tracks. By setting `explicit_forced_subs=yes`, forced subtitles will never be chosen unless a rule explicitly includes "forced" in `slang`.
-
 ## Examples
 
 The [sub_select.conf](/sub_select.conf) file contains all of the options for the script and their defaults. The [sub-select.json](/sub-select.json) file contains an example set of track matches.

--- a/sub-select.lua
+++ b/sub-select.lua
@@ -34,6 +34,9 @@ local o = {
     --observe audio switches and reselect the subtitles when alang changes
     observe_audio_switches = false,
 
+    --only select forced subtitles if they are explicitly included in slang
+    explicit_forced_subs = false,
+
     --the folder that contains the 'sub-select.json' file
     config = "~~/script-opts"
 }
@@ -146,6 +149,7 @@ local function is_valid_sub(sub, slang, pref)
     elseif slang == "forced" then
         if not sub.forced then return false end
     else
+        if sub.forced and o.explicit_forced_subs then return false end
         if not sub.lang:find(slang) and slang ~= "*" then return false end
     end
 

--- a/sub_select.conf
+++ b/sub_select.conf
@@ -24,8 +24,12 @@ detect_incorrect_predictions=yes
 #observe audio switches and reselect the subtitles when alang changes
 observe_audio_switches=no
 
-# only select forced subtitles if they are explicitly included in
-# slang
+# Only select forced subtitles if they are explicitly stated in slang.
+# By default, when searching for subtitle tracks with a specific language,
+# forced subtitles will be included in the search results and treated the same as other tracks.
+# This means that there's no way to write a rule that specifically excludes
+# forced subtitle tracks. By enabling this forced subtitles will never be chosen unless a rule
+# explicitly includes "forced" in `slang`.
 explicit_forced_subs=no
 
 # the folder that contains the 'sub-select.json' file

--- a/sub_select.conf
+++ b/sub_select.conf
@@ -24,5 +24,9 @@ detect_incorrect_predictions=yes
 #observe audio switches and reselect the subtitles when alang changes
 observe_audio_switches=no
 
+# only select forced subtitles if they are explicitly included in
+# slang
+explicit_forced_subs=no
+
 # the folder that contains the 'sub-select.json' file
 config=~~/script-opts


### PR DESCRIPTION
Currently, if I have a rule like
```json
{
  "alang": "j[ap]n?",
  "blacklist": ["sign"],
  "slang": ["eng?","und"]
}
```
if the first English subtitle track is forced, that track will still be chosen over other non-forced tracks. I want a way to write rules that specifically exclude forced subtitles, which isn't currently supported by the `blacklist` parameter.