### PR TITLE
Add experimental option to select audio tracks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # mpv-sub-select
 
 This script allows you to configure advanced subtitle track selection based on the current audio track and the names and language of the subtitle tracks. The script will automatically disable itself when mpv is started with `--sid` not set to `auto`, or when `--track-auto-selection` is disabled.
+There is also experimental mode which allows [audio selection](#audio-selection) as well.
 
 ## Configuration
 
@@ -87,11 +88,29 @@ The `detect_audio_switches` script-opt allows one to enable Auto-Switch Mode. In
 This setting ignores `--sid=auto`, but when using synchronous mode the script will not change the original `sid` until the first audio switch. This feature still respects `--track-auto-selection`.
 This mode can be disabled during runtime wi the `sub-select` script message shown above.
 
+## Audio Selection
+
+This is an experimental option to allow advanced selection of pairs of audio and subtitle
+tracks. Controlled by the `select_audio` option.
+
+When this option is enabled the script will go through the list
+of preferences as usual, but instead of comparing the sub tracks against the current audio
+track it will compare it against all audio tracks. If any audio tracks match the alang
+and there are subs that match the slang and filters, then that audio track will be
+selected.
+
+If multiple audio tracks match a preference then the track that occurs first in the
+track list will be chosen. This option does not break `observe_audio_switches`
+but will disable the `force_prediction` and `detect_incorrect_predictions` options.
+
+The `whitelist` and `blacklist` will still only work with subs, but the `condition` filter
+can be used to implement audio-specific filtering behaviour.
+
 ## Synchronous vs Asynchronous Track Selection
 
 The script has two different ways it can select subtitles, controlled with the `preload` script-opt. The default is to load synchronously during the preload phase, which is before track selection; this allows the script to seamlessly change the subtitles to the desired track without any indication that the tracks were switched manually. This likely has better compatability with other options and scripts.
 
-The downside of this method is that when `--aid` is set to auto the script needs to scan the track-list and predict what track mpv will select. Therefore, in some rare situations, this could result in the wrong audio track prediction, and hence the wrong subtitle being selected. There are three solutions to this problem:
+The downside of this method is that when `--aid` is set to auto the script needs to scan the track-list and predict what track mpv will select. Therefore, in some rare situations, this could result in the wrong audio track prediction, and hence the wrong subtitle being selected. There are several solutions to this problem:
 
 ### Use Asynchronous Mode (default no)
 
@@ -107,6 +126,10 @@ This method works well, but is not ideal if one wants to utilise a more refined 
 Check the audio track when playback starts and compare with the latest prediction, if the prediction was wrong then the subtitle selection is run again. This can be disabled with `detect_incorrect_predictions=no`. This is the best of both worlds, since 99% of the time the subtitles will load seamlessly, and on the rare occasion that the file has weird track tagging the correct subtitles will be reloaded. However, this method does have the highest computational overhead, if anyone cares about that.
 
 Auto-Select Mode enables this intrinsically.
+
+### Use audio selection mode (default no)
+
+See [Audio Selection](#audio-selection).
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ All titles are converted to lowercase automatically to allow more matches.
 This expression will be run for every subtitle that passes the other filters. The `sub` variable contains the subtitle
 track entry and `audio` contains the audio track entry. See the [track-list property](https://mpv.io/manual/master/#command-interface-track-list)
 for what fields are available. The `mp`, `mp.msg`, and `mp.utils` modules are avaialble as `mp`, `msg`, and `utils`, respectively.
+If no audio or sub track is being compared (which only happens if you set alang or slang to `no`) then `audio` or `sub` will evaluate to `nil`.
 
 ### String Matching
 

--- a/sub-select.json
+++ b/sub-select.json
@@ -22,10 +22,7 @@
         "whitelist": [ "sign", "song" ]
     },
     {
-        "alang": [
-            "eng?",
-            "no"
-        ],
+        "alang": "eng?",
         "slang": "no"
     },
     {
@@ -35,5 +32,9 @@
     {
         "alang": "*",
         "slang": "und"
+    },
+    {
+        "alang": "no",
+        "slang": "no"
     }
 ]

--- a/sub-select.lua
+++ b/sub-select.lua
@@ -90,7 +90,9 @@ local function evaluate_string(str, env)
         chunk = function() return nil end
     end
 
-    return chunk()
+    local success, boolean = pcall(chunk)
+    if not success then msg.error(boolean) end
+    return boolean
 end
 
 --anticipates the default audio track

--- a/sub-select.lua
+++ b/sub-select.lua
@@ -245,11 +245,13 @@ local function find_valid_tracks(manual_audio)
                     msg.debug("checking for valid sub:", slang)
 
                     --special handling when we want to disable subtitles
-                    if slang == "no" then return aid, 0 end
+                    if slang == "no"  and (not pref.condition or (evaluate_string('return '..pref.condition, { audio = audio_track or nil }) == true))then
+                        return aid, 0
+                    end
 
                     for _,sub_track in ipairs(sub_tracks) do
                         if  is_valid_sub(sub_track, slang, pref)
-                            and (not pref.condition or (evaluate_string('return '..pref.condition, { audio = audio_track, sub = sub_track }) == true))
+                            and (not pref.condition or (evaluate_string('return '..pref.condition, { audio = audio_track or nil, sub = sub_track }) == true))
                         then
                             return aid, sub_track.id
                         end

--- a/sub-select.lua
+++ b/sub-select.lua
@@ -286,7 +286,7 @@ end
 
 --select subtitles synchronously during the on_preloaded hook
 local function preload()
-    if o.select_audio then select_tracks() end
+    if o.select_audio then return select_tracks() end
 
     local audio = predict_audio()
     if o.force_prediction and next(audio) then set_track("aid", audio.id) end
@@ -343,7 +343,7 @@ if o.preload then
     end)
 
     --double check if the predicted subtitle was correct
-    if o.detect_incorrect_predictions and not o.force_prediction and not o.observe_audio_switches then
+    if o.detect_incorrect_predictions and not o.select_audio and not o.force_prediction and not o.observe_audio_switches then
         mp.register_event("file-loaded", reselect_subtitles)
     end
 else

--- a/sub-select.lua
+++ b/sub-select.lua
@@ -158,8 +158,8 @@ local function is_valid_audio(audio, pref)
     for _,lang in ipairs(alangs) do
         msg.debug("Checking for valid audio:", lang)
 
-        if (not audio or not next(audio)) and lang == "no" then
-            return true
+        if (not audio or not next(audio)) then
+            if lang == "no" then return true end
         elseif audio then
             if lang == '*' then
                 return true

--- a/sub-select.lua
+++ b/sub-select.lua
@@ -190,7 +190,7 @@ local function is_valid_sub(sub, slang, pref)
         if not sub.lang:find(slang) and slang ~= "*" then return false end
     end
 
-    local title = sub.title
+    local title = sub.title or ''
 
     -- if the whitelist is not set then we don't need to find anything
     local passes_whitelist = not pref.whitelist

--- a/sub-select.lua
+++ b/sub-select.lua
@@ -229,7 +229,7 @@ end
 --scans the track list and selects audio and subtitle tracks which match the track preferences
 --if an audio track is provided to the function it will assume this track is the only audio
 local function find_valid_tracks(manual_audio)
-    assert(manual_audio == nil or manual_audio == NO_TRACK or (type(manual_audio) == 'table' and manual_audio.id), 'argument must be an audio track or `false` for no')
+    assert(manual_audio == nil or (type(manual_audio) == 'table' and manual_audio.id), 'argument must be an audio track or nil')
 
     local sub_track_list = {NO_TRACK, unpack(sub_tracks)}
     local audio_track_list

--- a/sub_select.conf
+++ b/sub_select.conf
@@ -13,6 +13,10 @@ force_enable=no
 # disabling this will switch the subtitle track after playback starts
 preload=yes
 
+# experimental audio track selection based on the preference json file.
+# this overrides force_prection and detect_incorrect_predictions.
+select_audio=no
+
 # remove any potential prediction failures by forcibly selecting whichever
 # audio track was predicted
 force_prediction=no


### PR DESCRIPTION
Add new experimental option to select audio tracks.

When this option is enabled then the script will go through the list
of preferences, but instead of comparing the sub tracks against the current audio
track it will compare it against all audio tracks. If any audio tracks match the `alang`
and there are subs that match the `slang` and filters, then that audio track will be
selected.

If multiple audio tracks match a preference then the track that occurs first in the
track list will be chosen. This option does not break `observe_audio_switches`
but will disable the `force_prediction` and `detect_incorrect_predictions` options.

The `whitelist` and `blacklist` will still only work with subs, but the `condition` filter
can be used to implement audio-specific filtering behaviour.

Resolves #6 