### PR TITLE
Adds support for secondary subtitle selection and visibility preferences

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,21 +14,31 @@ The syntax and available options are as follows:
 ```json
 [
     {
-        "alang": "jpn",
-        "slang": "eng",
+        "alang": "jpn",                         // optional
+        "slang": "eng",                         // REQUIRED!!!
         "blacklist": [ "sign" ],                // optional
         "whitelist": [ "english", "song" ],     // optional
-        "condition": "sub.codec == 'ass'"       // optional
+        "condition": "sub.codec == 'ass'",      // optional
+        "secondary_slang": ["por", "ita?"],     // optional
+        "secondary_blacklist": [ "sign" ],      // optional
+        "secondary_whitelist": [ "brazilian", "song" ],         // optional
+        "secondary_condition": "secondary_sub.codec == 'ass'",  // optional
+        "sub_visibility": true,                 // optional
+        "secondary_sub_visibility": false       // optional
     }
 ]
 ```
 
+`slang` is the only setting which is required to be defined in every preference section. All other settings are optional.
+A preference section is defined between `{` and `}`, as the one seen above.
+
 `alang` and `slang` are the language codes of the audio and subtitle tracks,
-while `blacklist` and `whitelist` are optional filters that can be used to choose subtitle tracks based on their track names.
+while `blacklist` and `whitelist` are filters that can be used to choose subtitle tracks based on their track names.
 For a track to be selected it must match any entry in the `whitelist` and must not match any entry in the `blacklist`.
 
 `alang` and `slang` can also be arrays of valid codes to allow matching with multiple language codes.
 If multiple `slang` languages are included, then the first code to match to a track will be the one used.
+If `alang` is not defined it will match to any language.
 
 **Do not use uppercase characters for any options unless using [patterns](#string-matching).**
 
@@ -39,6 +49,15 @@ This expression will be run for every subtitle that passes the other filters. Th
 track entry and `audio` contains the audio track entry. See the [track-list property](https://mpv.io/manual/master/#command-interface-track-list)
 for what fields are available. The `mp`, `mp.msg`, and `mp.utils` modules are avaialble as `mp`, `msg`, and `utils`, respectively.
 If no audio or sub track is being compared (which only happens if you set alang or slang to `no`) then `audio` or `sub` will evaluate to `nil`.
+
+`secondary_slang`, `secondary_blacklist`, `secondary_whitelist` and `secondary_condition` only apply for the selection of secondary subtitles.
+They work the same as their counterparts.
+The selection of secondary subtitles always occurs after the selection of the audio track and primary subtitles, so `condition` can't access the `secondary_sub` variable, but `secondary_condition` has access to `audio`, `sub` and `secondary_sub`.
+No secondary subtitles will be selected, if `secondary_slang` is not set or matched, or no matching primary subtitle is selected (`no` still counts as a selectection).
+
+`sub_visibility` and `secondary_sub_visibility` set the visibility of the primary and secondary subtitles.
+Be aware that these might be overwritten by the mpv-native config options `sub-visibility` and `secondary-sub-visibility`.
+The subtitles can be toggled between visible and hidden by using the mpv-defined shortcut keys (by default `v` for primary subtitles and `Alt+v` for secondary ones).
 
 ### String Matching
 
@@ -53,6 +72,7 @@ The script moves down the list of track preferences until any valid pair of audi
 ### Special Strings
 
 There are a number of strings that can be used for the `alang` and `slang` which have special behaviour.
+If `alang` is not defined it defaults to `*`.
 
 **alang:**
 | String | Action                                  |
@@ -134,3 +154,21 @@ See [Audio Selection](#audio-selection).
 ## Examples
 
 The [sub_select.conf](/sub_select.conf) file contains all of the options for the script and their defaults. The [sub-select.json](/sub-select.json) file contains an example set of track matches.
+
+If all you want is to always display forced subtitles (if available), but also want to have hidden regular ones selected use the example below.
+This allows to use a key shortcut (`v` or `Alt+v` with mpv defaults) to toggle the normally hidden regular subtitles, even if the file has forced subtitles, which are always visible.
+
+```json
+[
+    {
+        "slang": ["forced"],
+        "secondary_slang": ["eng?"],
+        "sub_visibility": true,
+        "secondary_sub_visibility": false
+    },
+    {
+        "slang": ["eng?"],
+        "sub_visibility": false
+    }
+]
+```

--- a/sub-select.json
+++ b/sub-select.json
@@ -35,5 +35,15 @@
     {
         "alang": "*",
         "slang": "und"
+    },
+    {
+        "slang": ["forced"],
+        "secondary_slang": ["eng?", "ger", "deu?"],
+        "sub_visibility": true,
+        "secondary_sub_visibility": false
+    },
+    {
+        "slang": ["eng?", "ger", "deu?"],
+        "sub_visibility": false
     }
 ]

--- a/sub-select.lua
+++ b/sub-select.lua
@@ -319,14 +319,14 @@ local function find_valid_tracks(manual_audio)
                         msg.info("secondary subtitles =>", not sec_sid and "not set" or (sec_sid == 0 and "disabled" or (
                             sec_sub_track and sec_sub_track.lang or "unknown"
                         )), ";", sec_sub_track and sec_sub_track.title or "")
-                        return aid, sid, sec_sid
+                        return aid, sid, sec_sid, pref.sub_visibility, pref.secondary_sub_visibility
                     end
                 end
             end
         end
     end
     msg.info("no valid subtitles matching the preferences found")
-    return nil, nil, nil
+    return nil, nil, nil, nil, nil
 end
 
 
@@ -339,7 +339,7 @@ end
 --extract the language code from an audio track node and pass it to select_subtitles
 local function select_tracks(audio)
     -- if the audio track has no fields we assume that there is no actual track selected
-    local aid, sid, sec_sid = find_valid_tracks(audio)
+    local aid, sid, sec_sid, sub_visibility, sec_sub_visibility = find_valid_tracks(audio)
     if sid then
         set_track('sid', sid == 0 and 'no' or sid)
     end
@@ -348,6 +348,18 @@ local function select_tracks(audio)
     end
     if aid and o.select_audio then
         set_track('aid', aid == 0 and 'no' or aid)
+    end
+    if sub_visibility ~= nil then
+        msg.verbose("setting sub-visibility to", tostring(sub_visibility))
+        if not mp.get_property_bool("sub-visibility") == sub_visibility then
+            mp.set_property_bool("sub-visibility", sub_visibility)
+        end
+    end
+    if sec_sub_visibility ~= nil then
+        msg.verbose("setting secondary-sub-visibility to", tostring(sec_sub_visibility))
+        if not mp.get_property_bool("secondary-sub-visibility") == sec_sub_visibility then
+            mp.set_property_bool("secondary-sub-visibility", sec_sub_visibility)
+        end
     end
 
     latest_audio = find_current_audio()

--- a/sub-select.lua
+++ b/sub-select.lua
@@ -155,6 +155,9 @@ end
 local function is_valid_audio(audio, pref)
     local alangs = type(pref.alang) == "string" and {pref.alang} or pref.alang
 
+    --if alang is not set, allow any audio track
+    if not alangs then return true end
+
     for _,lang in ipairs(alangs) do
         msg.debug("Checking for valid audio:", lang)
 

--- a/sub_select.conf
+++ b/sub_select.conf
@@ -3,29 +3,29 @@
 ## https://github.com/CogentRedTester/mpv-sub-select ##
 #######################################################
 
-# forcibly enable the script regardless of the sid option
+# Forcibly enable the script regardless of the sid option
 force_enable=no
 
-# selects subtitles synchronously during the preloaded hook, which has better
-# compatability with other scripts and options
-# this requires that the script predict what the default audio track will be,
-# so theoretically this can be wrong on some rare occasions
-# disabling this will switch the subtitle track after playback starts
+# Selects subtitles synchronously during the preloaded hook, which has better
+# compatability with other scripts and options.
+# This requires that the script predict what the default audio track will be,
+# so theoretically this can be wrong on some rare occasions.
+# Disabling this will switch the subtitle track after playback starts.
 preload=yes
 
-# experimental audio track selection based on the preference json file.
-# this overrides force_prection and detect_incorrect_predictions.
+# Experimental audio track selection based on the preference json file.
+# This overrides `force_prediction` and `detect_incorrect_predictions`.
 select_audio=no
 
-# remove any potential prediction failures by forcibly selecting whichever
+# Remove any potential prediction failures by forcibly selecting whichever
 # audio track was predicted
 force_prediction=no
 
-# detect when a prediction is wrong and re-check the subtitles
-# this is automatically disabled if `force_prediction` is enabled
+# Detect when a prediction is wrong and re-check the subtitles
+# this is automatically disabled if `force_prediction` is enabled.
 detect_incorrect_predictions=yes
 
-#observe audio switches and reselect the subtitles when alang changes
+# Observe audio switches and reselect the subtitles when alang changes
 observe_audio_switches=no
 
 # Only select forced subtitles if they are explicitly stated in slang.
@@ -36,5 +36,5 @@ observe_audio_switches=no
 # explicitly includes "forced" in `slang`.
 explicit_forced_subs=no
 
-# the folder that contains the 'sub-select.json' file
+# Set the folder that contains the 'sub-select.json' file
 config=~~/script-opts


### PR DESCRIPTION
This PR is based on the audio-select branch so merge #17 first.

This only adds functionality and the way how audio and primary subtitles are selected is not affected. These functionalities have been added:

- Support for secondary subtitle selection, which occurs only after a primary subtitle has been selected
- Support for subtitle visibility settings
- alang is now optional and defaults to `*`
- After track selection there is a console output

New JSON config options:

```
secondary_slang
secondary_whitelist
secondary_blacklist
secondary_condition
sub_visibility
secondary_sub_visibility
```

For more information see the updated readme.

See mpv's notes on secondary subtitles: https://mpv.io/manual/master/#options-secondary-sid

An issue to add the option secondary-slang internally to mpv has been open since 6 years here: https://github.com/mpv-player/mpv/issues/4209
And an issue about not being able to hide/show subtitles depending on, if they are forced is open here: https://github.com/mpv-player/mpv/issues/4271
Both these issues are solved with this script now.

The reason why started working on this is to make this config possible:

```json
[
    {
        "slang": ["forced"],
        "secondary_slang": ["eng?"],
        "sub_visibility": true,
        "secondary_sub_visibility": false
    },
    {
        "slang": ["eng?"],
        "sub_visibility": false
    }
]
```

These preferences make sure that, if forced subtitles are available, they are always selected and made visible. If regular subtitles are available, they are selected, but the visibility hidden by default. They are selected as primary subtitles, if no forced subtitles exist and otherwise as secondary subtitles. This allows to quickly toggle regular subtitles between hidden and visible by using the key shortcuts (`v` and `Alt+v`).