### PR TITLE
Add inheritance for preferences

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ The syntax and available options are as follows:
         "slang": "eng",
         "blacklist": [ "sign" ],                // optional
         "whitelist": [ "english", "song" ],     // optional
-        "condition": "sub.codec == 'ass'"       // optional
+        "condition": "sub.codec == 'ass'",      // optional
+        "id": "unique-id",                      // optional
+        "inherit": "other-id"                   // optional
     }
 ]
 ```
@@ -69,6 +71,62 @@ There are a number of strings that can be used for the `alang` and `slang` which
 | no      | disables subs if `alang` matches              |
 | default | selects subtitles with the `default` tag      |
 | forced  | selects subtitles with the `forced` tag       |
+
+### Inheritance
+
+To make it easier to write complex config files you can set the preferences to inherit from each other.
+This will reduce the need to duplicate the same fields in multiple preferences. Inheritence uses the
+`id` and `inherit` fields. The `id` field must be a string that is unique to that preference
+(no two preferences can have the same ID). The `inherit` field can be used to specify the ID of the preference
+to inherit from. The special (reserved) ID `^` will inherit from the previous preference without it needing an explicit ID.
+
+The new child preference will inherit all the fields from the parent that have not been explicitly overwritten.
+Inheritance can be chained, but make sure not to create circular inheritance.
+
+In the below example the first preference inherits the `alang` and `slang` fields from the second preference.
+The first preference adds a `condition` field to prefer external subtitles.
+
+```json
+[
+    {
+        "inherit": "example-id",
+        "condition": "sub.external"
+    },
+    {
+        "alang": "*",
+        "slang": "eng?",
+        "id": "example-id",
+    }
+]
+```
+
+In this more complex example external subtitles are the main preference, followed
+by a preference for ass subtitles. The special `^` ID is used to simplify the config.
+Note the final preference needs to add a superfluous `condition` statement to override
+the inherited condition from the third preference.
+
+```json
+[
+    {
+        "alang": ["jpn", "ja"],
+        "slang": "eng",
+        "whitelist": [ "sign", "song"],
+        "condition": "sub.codec == 'ass' and sub.external" 
+    },
+    {
+        "inherit": "^",
+        "condition": "sub.external" 
+    },
+    {
+        "inherit": "^",
+        "condition": "sub.codec == 'ass'" 
+    },
+    {
+         "inherit": "^",
+         "condition": "sub.codec ~= 'ass'"
+    }
+]
+```
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -36,19 +36,13 @@ If multiple `slang` languages are included, then the first code to match to a tr
 
 All titles are converted to lowercase automatically to allow more matches.
 
-`condition` is an optional lua expression that can be used to evaluate whether or not the subtitle should be selected.
-This expression will be run for every subtitle that passes the other filters. The `sub` variable contains the subtitle
-track entry and `audio` contains the audio track entry. See the [track-list property](https://mpv.io/manual/master/#command-interface-track-list)
-for what fields are available. The `mp`, `mp.msg`, and `mp.utils` modules are avaialble as `mp`, `msg`, and `utils`, respectively.
-If no audio or sub track is being compared (which only happens if you set alang or slang to `no`) then `audio` or `sub` will evaluate to `nil`.
-
 ### String Matching
 
 All matching is done using the lua `string.find` function, so supports [patterns](https://www.lua.org/manual/5.1/manual.html#5.4.1). For example `eng?` could be used instead of `eng` so that the DVD language code `en` is also matched.
 
 **The characters `^$()%.[]*+-?` have special behaviour and muct be escaped with `%`.**
 
-### Preference
+### Priority
 
 The script moves down the list of track preferences until any valid pair of audio and subtitle tracks are found. Once this happens the script immediately sets the subtitle track and terminates. If none of the tracks match then track selection is deferred to mpv.
 
@@ -71,6 +65,21 @@ There are a number of strings that can be used for the `alang` and `slang` which
 | no      | disables subs if `alang` matches              |
 | default | selects subtitles with the `default` tag      |
 | forced  | selects subtitles with the `forced` tag       |
+
+### Conditions
+
+Conditions are a way to specify advanced, powerful, and custom filters.
+The `condition` field is a lua expression that can be used to evaluate whether or not the subtitle should be selected.
+This expression will be run for every subtitle that passes the other filters. The `sub` variable contains the subtitle
+track entry and `audio` contains the audio track entry. See the [track-list property](https://mpv.io/manual/master/#command-interface-track-list)
+for what fields are available. The `mp`, `mp.msg`, and `mp.utils` modules are avaialble as `mp`, `msg`, and `utils`, respectively.
+If no audio or sub track is being compared (which only happens if you set alang or slang to `no`) then `audio` or `sub` will evaluate to `nil`.
+
+In the following examples the condition requires:
+
+* `"condition": "sub.external"` - an external subtitle file.
+* `"condition": "audio.default and sub.id == 1"` - the default audio and the first subtitle in the file.
+* `"condition": "mp.get_property('path', ''):find("Anime") ~= nil"` - the path of the current file to contain `Anime`.
 
 ### Inheritance
 

--- a/sub-select.lua
+++ b/sub-select.lua
@@ -67,10 +67,7 @@ local function redirect_table(t, new)
 end
 
 local function type_check(val, t, required)
-    if not val and required then return false end
-
-    -- allows values to be nil
-    if not required then t = t..' nil' end
+    if val == nil then return not required end
     if not t:find(type(val)) then return false end
     return true
 end

--- a/sub-select.lua
+++ b/sub-select.lua
@@ -100,10 +100,7 @@ local function setup_prefs()
         assert(type_check(pref.inherit, 'string'), '`inherit` must be a string: '..pref_str)
 
         if pref.inherit then
-            local parent
-            if pref.inherit == '^' then parent = prefs[i-1]
-            else parent = IDs[pref.inherit] end
-
+            local parent = pref.inherit == '^' and prefs[i-1] or IDs[pref.inherit]
             assert(parent, 'failed to find matching id: '..pref_str)
             pref = redirect_table(parent, pref)
         end

--- a/sub-select.lua
+++ b/sub-select.lua
@@ -82,11 +82,13 @@ local function setup_prefs()
     prefs = utils.parse_json(json)
 
     assert(prefs, "Invalid JSON format in sub-select.json.")
+    local reservedIDs = { ['^'] = true }
     local IDs = {}
 
     -- storing the ID in the first pass
     for _, pref in ipairs(prefs) do
         if pref.id then
+            assert(not reservedIDs[pref.id], 'using reserved ID '..pref.id)
             assert(not IDs[pref.id], 'duplicate ID '..pref.id)
             IDs[pref.id] = pref
         end
@@ -122,6 +124,8 @@ setup_prefs()
 --the name argument is used for error reporting
 --provides the mpv modules and the fb module to the string
 local function evaluate_string(str, env)
+    msg.debug('evaluating string '..str)
+
     env = redirect_table(_G, env)
     env.mp = redirect_table(mp)
     env.msg = redirect_table(msg)


### PR DESCRIPTION
With the new `condition` field it is becoming necessary for
complex config files to require a large number of near-identical
preferences that only vary in one or two fields.

This PR adds a new inheritance system to allow for more concise
and easier to modify config files. It does this through the
addition of two new preference fields, the `id` field, and the
`inherit` field. `id` must be a string that is unique
to that preference (no two preferences can have the same ID).
The `inherit` field can be used to specify the ID of the preference
to inherit from. The special (reserved) ID `^` will inherit from
the previous preference without it needing an explicit ID.

For example the following json file is trying to preference
external subs over internal subs and secondarily prefer
ass subs over other subs.

```json
[
    {
        "alang": ["jpn", "ja"],
        "slang": "eng",
        "whitelist": [ "sign", "song"],
	"condition": "sub.codec == 'ass' and sub.external" 
    },
    {
        "alang": ["jpn", "ja"],
        "slang": "eng",
        "whitelist": [ "sign", "song"],
	"condition": "sub.external" 
    },
    {
        "alang": ["jpn", "ja"],
        "slang": "eng",
        "whitelist": [ "sign", "song"],
	"condition": "sub.codec == 'ass'" 
    },
    {
        "alang": ["jpn", "ja"],
        "slang": "eng",
        "whitelist": [ "sign", "song"],
    },
]
```

With inheritance you could much more concisely write this as:


```json
[
    {
        "alang": ["jpn", "ja"],
        "slang": "eng",
        "whitelist": [ "sign", "song"],
	"condition": "sub.codec == 'ass' and sub.external" 
    },
    {
        "inherit": "^",
	"condition": "sub.external" 
    },
    {
        "inherit": "^",
	"condition": "sub.codec == 'ass'" 
    },
    {
         "inherit": "^",
         "condition": "sub.codec ~= 'ass'"
    },
]
```

We have to add a superfluous condition field to the final preference
to overwrite the inherited conditions.