### PR TITLE
Make code for finding sub-select.json more flexible

### DIFF
--- a/sub-select.lua
+++ b/sub-select.lua
@@ -73,7 +73,7 @@ local function type_check(val, t, required)
 end
 
 local function setup_prefs()
-    local file = assert(io.open(mp.command_native({"expand-path", o.config}) .. "/sub-select.json"))
+    local file = assert(io.open(mp.command_native({"expand-path", o.config .. "/sub-select.json"})))
     local json = file:read("*all")
     file:close()
     prefs = utils.parse_json(json)


### PR DESCRIPTION
Rather than finding the first mpv config directory that contains `script-opts`, and then looking inside there for `sub-select.json`, we should find the first mpv config directory that contains `script-opts/sub-select.json`.