### PR TITLE
Lowercase track lang

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ the inherited condition from the third preference.
 [
     {
         "alang": ["jpn", "ja"],
-        "slang": "eng",
+        "slang": ["en%-us", "eng?"],
         "whitelist": [ "sign", "song"],
         "condition": "sub.codec == 'ass' and sub.external" 
     },

--- a/sub-select.json
+++ b/sub-select.json
@@ -1,7 +1,7 @@
 [
     {
         "alang": ["eng?", "und"],
-        "slang": ["eng?", "und"],
+        "slang": ["en%-us", "eng?", "und"],
         "condition": "sub.forced"
     },
     {
@@ -15,7 +15,7 @@
     },
     {
         "alang": "eng?",
-        "slang": [ "eng?", "und" ],
+        "slang": [ "en%-us", "eng?", "und" ],
         "whitelist": [ "sign", "song" ]
     },
     {
@@ -24,7 +24,7 @@
     },
     {
         "alang": "*",
-        "slang": [ "eng?", "und" ]
+        "slang": [ "en%-us", "eng?", "und" ]
     },
     {
         "alang": "no",

--- a/sub-select.lua
+++ b/sub-select.lua
@@ -216,7 +216,7 @@ local function is_valid_audio(audio, pref)
             elseif lang == "default" then
                 if audio.default then return true end
             else
-                if audio.lang and audio.lang:find(lang) then return true end
+                if audio.lang and audio.lang:lower():find(lang) then return true end
             end
         end
     end
@@ -238,7 +238,7 @@ local function is_valid_sub(sub, slang, pref)
             if not sub.forced then return false end
         else
             if sub.forced and o.explicit_forced_subs then return false end
-            if not sub.lang:find(slang) and slang ~= "*" then return false end
+            if not sub.lang:lower():find(slang) and slang ~= "*" then return false end
         end
     end
 


### PR DESCRIPTION
mpv commit https://github.com/mpv-player/mpv/commit/ab3b1744b9a6c7cc33e16538e175af2b00d3c2e3 introduces support for BCP 47 language tags,  which cause mixing of uppercase and lowercase characters in lang. Unify lowercase this to adapt to new behaviors.